### PR TITLE
CMakery for library installation and FetchContent compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,23 +7,91 @@
 #
 
 cmake_minimum_required (VERSION 3.22)
-project(plugin C CXX)
+project(TASKSTUBS VERSION 0.1 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 add_compile_options(-fPIC)
 set(CMAKE_EXE_LINKER_FLAGS -rdynamic)
 
-enable_testing()
-
-# The headers are all in timer_plugin
-include_directories(${CMAKE_SOURCE_DIR}/timer_plugin)
-
-# This directory has the timer instrumentation API that a library will use to instrument itself
+# This directory has the timer instrumentation API that a library
+# will use to instrument itself
 add_subdirectory(timer_plugin)
 
-# This directory has a demonstration tool that a measurement library would implement
-add_subdirectory(tool_example)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  # If we're configuring this project standalone, we want testers
+  # and examples
+  enable_testing()
 
-# This directory has simple examples
-add_subdirectory(examples)
+  # This directory has a demonstration tool that a measurement
+  # library would implement
+  add_subdirectory(tool_example)
 
+  # This directory has simple examples
+  add_subdirectory(examples)
+endif (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+
+## All the installation things go here ##
+
+# for CMAKE_INSTALL_INCLUDEDIR definition
+include(GNUInstallDirs)
+
+set(public_headers
+  timer_plugin/plugin.h
+  timer_plugin/tasktimer.h
+  timer_plugin/tool_api.h)
+
+foreach(header ${public_headers})
+    file(REAL_PATH "${header}" full_header)
+    file(RELATIVE_PATH header_file_path "${CMAKE_CURRENT_SOURCE_DIR}" "${full_header}")
+    get_filename_component(header_directory_path "${header_file_path}" DIRECTORY)
+    install(
+        FILES ${header}
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${header_directory_path}"
+    )
+endforeach()
+
+# install the target and create export-set
+install(TARGETS timer_plugin
+    EXPORT "${PROJECT_NAME}Targets"
+    # these get default values from GNUInstallDirs, no need to set them
+    #RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} # bin
+    #LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
+    #ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # lib
+    # except for public headers, as we want them to be inside a library folder
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} # include/SomeLibrary
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # include
+)
+
+# generate and install export file
+install(EXPORT "${PROJECT_NAME}Targets"
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE ${namespace}::
+    DESTINATION cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+# generate the version file for the config file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION "${TASKSTUBS_VERSION}"
+    COMPATIBILITY AnyNewerVersion
+)
+# create config file
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION cmake
+)
+# install config files
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION cmake
+)
+# generate the export targets for the build tree
+# (can't say what this one is for, but so far it has been only causing me problems,
+# so I stopped adding it to projects)
+# export(EXPORT "${PROJECT_NAME}Targets"
+#     FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake"
+#     NAMESPACE ${namespace}::
+#)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components(@PROJECT_NAME@)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 # Simple example in C, instrumentation disabled entirely!
 add_executable(main_c_without main.c)
+target_include_directories(main_c_without PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../timer_plugin)
 # Simple example in C, instrumentation enabled
 add_executable(main_c_with main.c)
 target_compile_definitions(main_c_with PRIVATE TASKTIMER_USE_TIMERS)
@@ -16,6 +17,7 @@ target_link_libraries(main_c_with timer_plugin)
 
 # Simple example in C++, instrumentation disabled entirely!
 add_executable(main_cpp_without main.cpp)
+target_include_directories(main_cpp_without PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../timer_plugin)
 # Simple example in C++, instrumentation enabled
 add_executable(main_cpp_with main.cpp)
 target_compile_definitions(main_cpp_with PRIVATE TASKTIMER_USE_TIMERS)

--- a/timer_plugin/CMakeLists.txt
+++ b/timer_plugin/CMakeLists.txt
@@ -6,16 +6,27 @@
 # file LICENSE)
 #
 
-# Include this directory when searching for headers
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+SET(TIMERLIB "timer_plugin")
 
-# Create the library with two source files
-add_library(timer_plugin tasktimer.c plugin.c)
+# Create the library target
+add_library(${TIMERLIB})
+
+# and add the two source files to it
+target_sources(${TIMERLIB} PRIVATE
+  tasktimer.c plugin.c)
+
+# We define the headers per target so CMake knows how to
+# install things better
+target_include_directories(${TIMERLIB} 
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>  
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}> 
+)  
 
 # There is a dependency on libdl.so
-target_link_libraries(timer_plugin dl)
+target_link_libraries(${TIMERLIB} dl)
 
 # Enable GNU extensions to define RTLD_DEFAULT for the dlsym() call.
-target_compile_definitions(timer_plugin PRIVATE _GNU_SOURCE)
+target_compile_definitions(${TIMERLIB} PRIVATE _GNU_SOURCE)
 
 

--- a/tool_example/CMakeLists.txt
+++ b/tool_example/CMakeLists.txt
@@ -12,6 +12,9 @@ add_library(MyToolC SHARED my_tool.c)
 # Our tool has a dependency on libdl.so
 target_link_libraries(MyToolC dl)
 
+# Our tool needs to find the plugin_timer includes
+target_include_directories(MyToolC PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../timer_plugin/)
+
 # Make sure we export symbols that the plugin loader will look for
 target_compile_definitions(MyToolC PRIVATE COMPILE_PLUGIN)
 


### PR DESCRIPTION
Only CMake changes (proposal) to make the code easier to pull via FetchContent mechanism.
I'm following (roughly) https://decovar.dev/blog/2021/03/08/cmake-cpp-library/

This proposal includes some name changes, and requires to explicitly add the plugin_timer include directory to the targets that do not link with the library, but that was the case before (just hidden behind the global include_directories).

I have tested it configures and compiles, but I haven't tested the FetchContent yet. Probably more tweaking to do for namespacing, just wanted to open this for comments.
